### PR TITLE
init aspects after all modules are loaded, not within bootstrap

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -11,27 +11,35 @@
 namespace Go\ZF2\GoAopModule;
 
 use Go\Core\AspectContainer;
-use Zend\EventManager\EventInterface;
-use Zend\ModuleManager\Feature\BootstrapListenerInterface;
 use Zend\ModuleManager\Feature\ConfigProviderInterface;
-use Zend\Mvc\MvcEvent;
+use Zend\ModuleManager\Feature\InitProviderInterface;
+use Zend\ModuleManager\ModuleEvent;
+use Zend\ModuleManager\ModuleManagerInterface;
 
 /**
  * ZF2 Module for registration of Go! AOP Framework
  */
-class Module implements ConfigProviderInterface, BootstrapListenerInterface
+class Module implements ConfigProviderInterface, InitProviderInterface
 {
+    /**
+     * @inheritDoc
+     */
+    public function init(ModuleManagerInterface $manager)
+    {
+        $manager->getEventManager()->attach(
+            ModuleEvent::EVENT_LOAD_MODULES_POST,
+            [ $this, 'initializeAspects']
+        );
+    }
 
     /**
-     * Listen to the bootstrap event
+     * Register aspects after all modules are loaded.
      *
-     * @param MvcEvent|EventInterface $e
-     *
-     * @return array
+     * @param ModuleEvent $e
      */
-    public function onBootstrap(EventInterface $e)
+    public function initializeAspects(ModuleEvent $e)
     {
-        $serviceManager = $e->getApplication()->getServiceManager();
+        $serviceManager = $e->getParam('ServiceManager');
 
         /** @var AspectContainer $aspectContainer */
         $aspectContainer = $serviceManager->get(AspectContainer::class);


### PR DESCRIPTION
This fix is required when you use the listeners config key to register listener before any bootstrap is happening.

If you have an aspect within these listeners or their dependencies the aop aspects are not registered.
The aop classloader could not exchange them so any annotation does not work.

With this change every aspect is registered right after the modules are loaded and before any listener is registered or any bootstrapping has happened.

Feel free for any questions.