### PR TITLE
[Improvement] Increase listener priority to the maximum value to be first

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -28,7 +28,7 @@ class Module implements ConfigProviderInterface, InitProviderInterface
     {
         $manager->getEventManager()->attach(
             ModuleEvent::EVENT_LOAD_MODULES_POST,
-            [ $this, 'initializeAspects']
+            [ $this, 'initializeAspects', PHP_INT_MAX ]
         );
     }
 


### PR DESCRIPTION
If you have several listeners on the EVENT_LOAD_MODULES_POST event it must be safe that the aspects are registered as first listener. 

Of course this does not work when some one else registers himself with this priority.

And would you mind, when this is merged, setting a new tag, so we don't have to rely on dev-master within our composer json?