### PR TITLE
fix syntax of callback

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -28,7 +28,8 @@ class Module implements ConfigProviderInterface, InitProviderInterface
     {
         $manager->getEventManager()->attach(
             ModuleEvent::EVENT_LOAD_MODULES_POST,
-            [ $this, 'initializeAspects', PHP_INT_MAX ]
+            [ $this, 'initializeAspects' ],
+            1000000
         );
     }
 


### PR DESCRIPTION
I made a huge mistake last time. The callback syntax was invalid.

I also reduced the priority so that other modules still have the chance to attach before go aop starts.

@lisachenko This must be merged immediately.

Sorry for the mistake again.