### PR TITLE
remove priority because zend service manager is not initialized at th…

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -28,8 +28,7 @@ class Module implements ConfigProviderInterface, InitProviderInterface
     {
         $manager->getEventManager()->attach(
             ModuleEvent::EVENT_LOAD_MODULES_POST,
-            [ $this, 'initializeAspects' ],
-            1000000
+            [ $this, 'initializeAspects' ]
         );
     }
 


### PR DESCRIPTION
This is total shit.

The priority is not even working because the service listener fills the service manager with a priority of 1.

@lisachenko i hope i haven't caused too much trouble 