### PR TITLE
Remove full requirement zendframework/zendframework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,15 @@
     "description": "Integration module for Go! AOP Framework",
     "type": "library",
     "keywords": ["module", "zend", "zf2", "aop", "php", "aspect"],
+    "license": "MIT",
     "require": {
         "goaop/framework": "^1.0|^2.0",
-        "zendframework/zendframework": "^2.0 | ^3.0"
+        "zendframework/zend-modulemanager": "^2.0 | ^3.0"
     },
-    "license": "MIT",
+    "require-dev": {
+        "phpunit/phpunit": "^5.0 | ^6.0",
+        "zendframework/zend-mvc": "^2.0 | ^3.0"
+    },
     "authors": [
         {
             "name": "Lisachenko Alexander",


### PR DESCRIPTION
Since this package only needs `zendframework/zend-modulemanager` to work and load the module.
I removed the full requirement on the whole `zendframework` package.

This requirement made it impossible to use `goaop-zf2-module` and `phpunit/phpunit:^6.0`.
Using `zendframework/zendframework:^2.0` the `zenframework/zend-test:^2.6` was required which works **only** with `phpunit/phpunit:^4.0 | ^5.0`

Also require phpunit and zend-mvc as development requirement.