### PR TITLE
Namespace change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /vendor/
 composer.lock
+
+# Test specific ignores
+tests/resources/cache

--- a/bin/goaop-zf2-warmup
+++ b/bin/goaop-zf2-warmup
@@ -2,7 +2,7 @@
 <?php
 
 use Go\Core\AspectKernel;
-use Go\ZF2\GoAopModule\Console\Warmup\Zf2WarmupCommand;
+use Go\Zend\Framework\Console\Command\WarmupCommand;
 use Symfony\Component\Console\Application;
 
 
@@ -27,6 +27,6 @@ if (!class_exists('Symfony\Component\Console\Application')) {
 }
 
 $app = new Application('Go! AOP', AspectKernel::VERSION);
-$app->add(new Zf2WarmupCommand());
+$app->add(new WarmupCommand());
 $app->run();
 

--- a/bin/goaop-zf2-warmup
+++ b/bin/goaop-zf2-warmup
@@ -19,6 +19,14 @@ if (is_dir($vendor = __DIR__ . '/../vendor')) {
     );
 }
 
+if (!class_exists('Symfony\Component\Console\Application')) {
+    die(
+        'You must install the symfony/console package in order ' .
+        'to use the command-line tool.' . PHP_EOL
+    );
+}
+
+
 $app = new Application('Go! AOP', AspectKernel::VERSION);
 $app->add(new WarmupCommand());
 $app->run();

--- a/bin/goaop-zf2-warmup
+++ b/bin/goaop-zf2-warmup
@@ -19,13 +19,6 @@ if (is_dir($vendor = __DIR__ . '/../vendor')) {
     );
 }
 
-if (!class_exists('Symfony\Component\Console\Application')) {
-    die(
-        'You must install the symfony/console package in order ' .
-        'to use the command-line tool.' . PHP_EOL
-    );
-}
-
 $app = new Application('Go! AOP', AspectKernel::VERSION);
 $app->add(new WarmupCommand());
 $app->run();

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "license": "MIT",
     "require": {
         "goaop/framework": "^1.0|^2.0",
-        "zendframework/zend-modulemanager": "^2.0 | ^3.0"
+        "zendframework/zend-modulemanager": "^2.0 | ^3.0",
+        "symfony/console": "^3.0 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 | ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,7 @@
     "license": "MIT",
     "require": {
         "goaop/framework": "^1.0|^2.0",
-        "zendframework/zend-modulemanager": "^2.0 | ^3.0",
-        "symfony/console": "^3.0 || ^4.0"
+        "zendframework/zend-modulemanager": "^2.0 | ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 | ^6.0",
@@ -17,6 +16,9 @@
         "zendframework/zend-log": "^2.0",
         "zendframework/zend-i18n": "^2.0",
         "zendframework/zend-console": "^2.0"
+    },
+    "suggest": {
+        "symfony/console": "Required to use goaop console warmup"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "goaop/framework": "^1.0|^2.0",
-        "zendframework/zend-modulemanager": "^2.0 | ^3.0"
+        "zendframework/zend-modulemanager": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 | ^6.0",
@@ -15,7 +15,8 @@
         "zendframework/zend-serializer": "^2.0",
         "zendframework/zend-log": "^2.0",
         "zendframework/zend-i18n": "^2.0",
-        "zendframework/zend-console": "^2.0"
+        "zendframework/zend-console": "^2.0",
+        "symfony/console": "^3.0 | ^4.0"
     },
     "suggest": {
         "symfony/console": "Required to use goaop console warmup"

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,12 @@
     "bin": ["bin/goaop-zf2-warmup"],
     "autoload": {
         "psr-4": {
-            "Go\\ZF2\\GoAopModule\\" : "src/"
+            "Go\\Zend\\Framework\\" : "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Go\\ZF2\\GoAopModule\\Tests\\" : "tests/"
+            "Go\\Zend\\Framework\\Tests\\" : "tests/"
         }
     }
 }

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -94,12 +94,14 @@ $moduleConfig = [
 ];
 
 return [
-    'goaop_module'    => $moduleConfig,
+    \Go\Zend\Framework\Module::CONFIG_KEY => $moduleConfig,
+
     'service_manager' => [
         'factories' => [
             AspectKernel::class    => AspectKernelFactory::class,
             AspectContainer::class => AspectContainerFactory::class,
         ]
     ],
-    'goaop_aspect' => []
+
+    \Go\Zend\Framework\Module::ASPECT_CONFIG_KEY => []
 ];

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -9,8 +9,8 @@
 use Go\Core\AspectContainer;
 use Go\Core\AspectKernel;
 use Go\Core\GoAspectContainer;
-use Go\ZF2\GoAopModule\Factory\AspectContainerFactory;
-use Go\ZF2\GoAopModule\Factory\AspectKernelFactory;
+use Go\Zend\Framework\Factory\AspectContainerFactory;
+use Go\Zend\Framework\Factory\AspectKernelFactory;
 
 $basicDirectory = defined('APPLICATION_PATH') ? APPLICATION_PATH : __DIR__ . '/../../../..';
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,7 @@
         <testsuite name="Go! AOP ZF Module Test Suite">
             <directory>./tests/Integration/</directory>
             <directory>./tests/Unit/</directory>
+            <directory>./tests/Functional/</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/src/Console/Command/WarmupCommand.php
+++ b/src/Console/Command/WarmupCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Go\ZF2\GoAopModule\Console\Warmup;
+namespace Go\Zend\Framework\Console\Command;
 
 use Go\Core\AspectKernel;
 use Go\Instrument\ClassLoading\SourceTransformingLoader;
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Zf2WarmupCommand extends Command
+class WarmupCommand extends Command
 {
     /**
      * {@inheritDoc}

--- a/src/Factory/AspectContainerFactory.php
+++ b/src/Factory/AspectContainerFactory.php
@@ -8,7 +8,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Go\ZF2\GoAopModule\Factory;
+namespace Go\Zend\Framework\Factory;
 
 use Go\Core\AspectKernel;
 use Interop\Container\ContainerInterface;

--- a/src/Factory/AspectKernelFactory.php
+++ b/src/Factory/AspectKernelFactory.php
@@ -8,9 +8,10 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Go\ZF2\GoAopModule\Factory;
+namespace Go\Zend\Framework\Factory;
 
-use Go\ZF2\GoAopModule\Kernel\AspectZf2Kernel;
+use Go\Zend\Framework\Kernel\AspectKernel;
+use Go\Zend\Framework\Module;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;

--- a/src/Factory/AspectKernelFactory.php
+++ b/src/Factory/AspectKernelFactory.php
@@ -44,8 +44,8 @@ class AspectKernelFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $aspectKernel = AspectZf2Kernel::getInstance();
-        $aspectKernel->init($serviceLocator->get('config')['goaop_module']);
+        $aspectKernel = AspectKernel::getInstance();
+        $aspectKernel->init($serviceLocator->get('config')[Module::CONFIG_KEY]);
 
         return $aspectKernel;
     }

--- a/src/Kernel/AspectKernel.php
+++ b/src/Kernel/AspectKernel.php
@@ -8,16 +8,15 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Go\ZF2\GoAopModule\Kernel;
+namespace Go\Zend\Framework\Kernel;
 
 
 use Go\Core\AspectContainer;
-use Go\Core\AspectKernel;
 
 /**
- * ZF2 aspect kernel class
+ * Aspect kernel class
  */
-class AspectZf2Kernel extends AspectKernel
+class AspectKernel extends \Go\Core\AspectKernel
 {
 
     /**

--- a/src/Module.php
+++ b/src/Module.php
@@ -17,10 +17,13 @@ use Zend\ModuleManager\ModuleEvent;
 use Zend\ModuleManager\ModuleManagerInterface;
 
 /**
- * ZF2 Module for registration of Go! AOP Framework
+ * Module for registration of Go! AOP Framework
  */
 class Module implements ConfigProviderInterface, InitProviderInterface
 {
+    public const CONFIG_KEY = 'goaop_module';
+    public const ASPECT_CONFIG_KEY = 'goaop_aspect';
+
     /**
      * @inheritDoc
      */
@@ -44,7 +47,8 @@ class Module implements ConfigProviderInterface, InitProviderInterface
         /** @var AspectContainer $aspectContainer */
         $aspectContainer = $serviceManager->get(AspectContainer::class);
         $config          = $serviceManager->get('config');
-        $listOfAspects   = $config['goaop_aspect'];
+        $listOfAspects   = $config[self::ASPECT_CONFIG_KEY];
+
         foreach ($listOfAspects as $aspectService) {
             $aspect = $serviceManager->get($aspectService);
             $aspectContainer->registerAspect($aspect);

--- a/src/Module.php
+++ b/src/Module.php
@@ -21,8 +21,8 @@ use Zend\ModuleManager\ModuleManagerInterface;
  */
 class Module implements ConfigProviderInterface, InitProviderInterface
 {
-    public const CONFIG_KEY = 'goaop_module';
-    public const ASPECT_CONFIG_KEY = 'goaop_aspect';
+    const CONFIG_KEY = 'goaop_module';
+    const ASPECT_CONFIG_KEY = 'goaop_aspect';
 
     /**
      * @inheritDoc

--- a/src/Module.php
+++ b/src/Module.php
@@ -8,7 +8,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Go\ZF2\GoAopModule;
+namespace Go\Zend\Framework;
 
 use Go\Core\AspectContainer;
 use Zend\ModuleManager\Feature\ConfigProviderInterface;

--- a/tests/Advice/TestAdvice.php
+++ b/tests/Advice/TestAdvice.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Go\Zend\Framework\Tests\Advice;
+
+/**
+ * @package Go\Zend\Framework\Tests\Advice
+ */
+class TestAdvice
+{
+    public function getTest($parameter)
+    {
+    }
+}

--- a/tests/Aspect/TestAspect.php
+++ b/tests/Aspect/TestAspect.php
@@ -1,11 +1,13 @@
 <?php
 
-namespace Go\ZF2\GoAopModule\Tests\Aspect;
+namespace Go\Zend\Framework\Tests\Aspect;
 
 use Go\Aop\Aspect;
+use Go\Aop\Intercept\MethodInvocation;
+use Go\Lang\Annotation\Around;
 
 /**
- * @package Go\ZF2\GoAopModule\Tests\Aspect
+ * @package Go\Zend\Framework\Tests\Aspect
  */
 class TestAspect implements Aspect
 {

--- a/tests/Aspect/TestAspect.php
+++ b/tests/Aspect/TestAspect.php
@@ -11,5 +11,11 @@ use Go\Lang\Annotation\Around;
  */
 class TestAspect implements Aspect
 {
-
+    /**
+     * @param MethodInvocation $invocation
+     * @Around("execution(public Go\Zend\Framework\Tests\Advice\TestAdvice->get*(*))")
+     */
+    public function aspectAdvice(MethodInvocation $invocation)
+    {
+    }
 }

--- a/tests/Functional/WarmupTest.php
+++ b/tests/Functional/WarmupTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Go\Zend\Framework\Tests\Functional;
+
+use Go\Zend\Framework\Console\Command\WarmupCommand;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\Input;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @package Go\Zend\Framework\Tests\Functional
+ */
+class WarmupTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itShouldFindAdviceAccordingToConfig()
+    {
+        $input = $this->prophesize(InputInterface::class);
+        $input->bind(Argument::any())->willReturn();
+        $input->isInteractive()->willReturn(false);
+        $input->hasArgument(Argument::any())->willReturn(false);
+        $input->validate()->willReturn();
+
+        $input->getArgument('applicationConfig')
+            ->willReturn(__DIR__ . '/../resources/application_config.php');
+
+        $output = $this->getMockBuilder(OutputInterface::class)
+            ->setMethods(['writeln'])
+            ->getMockForAbstractClass();
+
+        $output->expects($this->at(1))
+            ->method('writeln')
+            ->with('Total <info>1</info> files to process.');
+
+        $command = new WarmupCommand();
+        $command->run($input->reveal(), $output);
+    }
+}

--- a/tests/Integration/ModuleTest.php
+++ b/tests/Integration/ModuleTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Go\ZF2\GoAopModule\Tests\Integration;
+namespace Go\Zend\Framework\Tests\Integration;
 
 use Go\Core\AspectContainer;
 use Go\Core\GoAspectContainer;
-use Go\ZF2\GoAopModule\Tests\Aspect\TestAspect;
+use Go\Zend\Framework\Tests\Aspect\TestAspect;
 use PHPUnit\Framework\TestCase;
 use Zend\Mvc\Application;
 
 /**
- * @package Go\ZF2\GoAopModule\Tests\Integration
+ * @package Go\Zend\Framework\Tests\Integration
  */
 class ModuleTest extends TestCase
 {

--- a/tests/Unit/Factory/AspectContainerFactoryTest.php
+++ b/tests/Unit/Factory/AspectContainerFactoryTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Go\ZF2\GoAopModule\Tests\Unit\Factory;
+namespace Go\Zend\Framework\Tests\Unit\Factory;
 
 use Go\Core\AspectContainer;
 use Go\Core\AspectKernel;
-use Go\ZF2\GoAopModule\Factory\AspectContainerFactory;
+use Go\Zend\Framework\Factory\AspectContainerFactory;
 use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
- * @package Go\ZF2\GoAopModule\Tests\Unit\Factory
+ * @package Go\Zend\Framework\Tests\Unit\Factory
  */
 class AspectContainerFactoryTest extends TestCase
 {

--- a/tests/Unit/Factory/AspectKernelFactoryTest.php
+++ b/tests/Unit/Factory/AspectKernelFactoryTest.php
@@ -20,7 +20,7 @@ class AspectKernelFactoryTest extends TestCase
     {
         $serviceLocator = $this->prophesize(ServiceLocatorInterface::class);
         $serviceLocator->get('config')
-            ->willReturn(['goaop_module' => require __DIR__ . '/../../resources/goaop_module.php'])
+            ->willReturn([Module::CONFIG_KEY => require __DIR__ . '/../../resources/goaop_module.php'])
             ->shouldBeCalled();
 
         $factory = new AspectKernelFactory();
@@ -41,7 +41,7 @@ class AspectKernelFactoryTest extends TestCase
     {
         $serviceLocator = $this->prophesize(ServiceLocatorInterface::class);
         $serviceLocator->get('config')
-            ->willReturn(['goaop_module' => require __DIR__ . '/../../resources/goaop_module.php'])
+            ->willReturn([Module::CONFIG_KEY => require __DIR__ . '/../../resources/goaop_module.php'])
             ->shouldBeCalled();
 
         $factory = new AspectKernelFactory();

--- a/tests/Unit/Factory/AspectKernelFactoryTest.php
+++ b/tests/Unit/Factory/AspectKernelFactoryTest.php
@@ -1,14 +1,15 @@
 <?php
 
-namespace Go\ZF2\GoAopModule\Tests\Unit\Factory;
+namespace Go\Zend\Framework\Tests\Unit\Factory;
 
 use Go\Core\AspectKernel;
-use Go\ZF2\GoAopModule\Factory\AspectKernelFactory;
+use Go\Zend\Framework\Factory\AspectKernelFactory;
+use Go\Zend\Framework\Module;
 use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
- * @package Go\ZF2\GoAopModule\Tests\Unit\Factory
+ * @package Go\Zend\Framework\Tests\Unit\Factory
  */
 class AspectKernelFactoryTest extends TestCase
 {

--- a/tests/Unit/ModuleTest.php
+++ b/tests/Unit/ModuleTest.php
@@ -66,7 +66,7 @@ class ModuleTest extends TestCase
             ->willReturn($aspectContainer->reveal())
             ->shouldBeCalled();
         $serviceManager->get('config')
-            ->willReturn(['goaop_aspect' => ['testAspect']])
+            ->willReturn([Module::ASPECT_CONFIG_KEY => ['testAspect']])
             ->shouldBeCalled();
         $serviceManager->get('testAspect')
             ->willReturn($aspect)

--- a/tests/Unit/ModuleTest.php
+++ b/tests/Unit/ModuleTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Go\ZF2\GoAopModule\Tests\Unit;
+namespace Go\Zend\Framework\Tests\Unit;
 
 use Go\Aop\Aspect;
 use Go\Core\AspectContainer;
-use Go\ZF2\GoAopModule\Module;
+use Go\Zend\Framework\Module;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Zend\EventManager\EventManagerInterface;
@@ -13,7 +13,7 @@ use Zend\ModuleManager\ModuleManagerInterface;
 use Zend\ServiceManager\ServiceManager;
 
 /**
- * @package Go\ZF2\GoAopModule\Tests\Unit
+ * @package Go\Zend\Framework\Tests\Unit
  */
 class ModuleTest extends TestCase
 {

--- a/tests/resources/application_config.php
+++ b/tests/resources/application_config.php
@@ -18,5 +18,5 @@ return [
         'config_glob_paths' => [
             __DIR__ . '/{{,*.}global,{,*.}local}.php',
         ],
-    ],
+    ]
 ];

--- a/tests/resources/application_config.php
+++ b/tests/resources/application_config.php
@@ -1,7 +1,7 @@
 <?php
 
 $modules = [
-    'Go\ZF2\GoAopModule',
+    'Go\Zend\Framework',
 ];
 
 if (class_exists('Zend\Router\Module')) {
@@ -14,6 +14,7 @@ return [
         'module_paths' => [
             __DIR__ . '/../../vendor',
         ],
+
         'config_glob_paths' => [
             __DIR__ . '/{{,*.}global,{,*.}local}.php',
         ],

--- a/tests/resources/global.php
+++ b/tests/resources/global.php
@@ -1,9 +1,10 @@
 <?php
 
 return [
-    'goaop_module'    => require 'goaop_module.php',
-    'goaop_aspect'    => [
-        \Go\ZF2\GoAopModule\Tests\Aspect\TestAspect::class,
+    \Go\Zend\Framework\Module::CONFIG_KEY => require 'goaop_module.php',
+
+    \Go\Zend\Framework\Module::ASPECT_CONFIG_KEY => [
+        \Go\Zend\Framework\Tests\Aspect\TestAspect::class,
     ],
 
     'service_manager' => [

--- a/tests/resources/global.php
+++ b/tests/resources/global.php
@@ -5,9 +5,10 @@ return [
     'goaop_aspect'    => [
         \Go\ZF2\GoAopModule\Tests\Aspect\TestAspect::class,
     ],
+
     'service_manager' => [
         'factories' => [
-            \Go\ZF2\GoAopModule\Tests\Aspect\TestAspect::class => \Zend\ServiceManager\Factory\InvokableFactory::class,
+            \Go\Zend\Framework\Tests\Aspect\TestAspect::class => \Zend\ServiceManager\Factory\InvokableFactory::class,
         ],
     ],
 ];

--- a/tests/resources/goaop_module.php
+++ b/tests/resources/goaop_module.php
@@ -2,11 +2,13 @@
 
 return [
     'debug'          => true,
-    'appDir'         => __DIR__,
-    'cacheDir'       => __DIR__,
+    'appDir'         => __DIR__ . '/../',
+    'cacheDir'       => __DIR__ . '/cache',
     'cacheFileMode'  => 0770 & ~umask(),
     'features'       => 0,
-    'includePaths'   => [],
+    'includePaths'   => [
+        __DIR__ . '/../Advice'
+    ],
     'excludePaths'   => [],
     'containerClass' => \Go\Core\GoAspectContainer::class,
 ];


### PR DESCRIPTION
**Changelog**

- move namespace according to goaop namespace.
- add functional test for warmup
- remove zf2 specific namings

**Version suggestion**: 2.0

**Question:**
I don't quite know if it works with ZF3 as a module. Do we need the support here or should we simply point to the new `zend-expressive-middleware` for goaop? Otherwise I would add a comment in the `README.md` to point that one out and remove the requirement in `composer.json`