### PR TITLE
Tests with multiple zf versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
 
 before_install:
   - phpenv config-rm xdebug.ini
-   - if [ "$ZF_VERSION" = "2" ]; then sed 's/ | ^3.0//g' composer.json > composer_v27.json; rm composer.json; mv composer_v27.json composer.json; fi
+  - if [ "$ZF_VERSION" = "2" ]; then sed 's/ | ^3.0//g' composer.json > composer_v27.json; rm composer.json; mv composer_v27.json composer.json; fi
 
 install:
   - composer install --no-progress --no-interaction --prefer-dist --no-suggest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,18 @@ php:
   - 7.1
 
 matrix:
+  include:
+    - php: 5.6
+      env: ZF_VERSION=2
+    - php: 7.0
+      env: ZF_VERSION=2
+    - php: 7.1
+      env: ZF_VERSION=2
   fast_finish: true
 
 before_install:
   - phpenv config-rm xdebug.ini
+   - if [ "$ZF_VERSION" = "2" ]; then sed 's/ | ^3.0//g' composer.json > composer_v27.json; rm composer.json; mv composer_v27.json composer.json; fi
 
 install:
   - composer install --no-progress --no-interaction --prefer-dist --no-suggest

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,12 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 | ^6.0",
-        "zendframework/zend-mvc": "^2.0 | ^3.0"
+        "zendframework/zend-mvc": "^2.0 | ^3.0",
+        "zendframework/zend-view": "^2.0",
+        "zendframework/zend-serializer": "^2.0",
+        "zendframework/zend-log": "^2.0",
+        "zendframework/zend-i18n": "^2.0",
+        "zendframework/zend-console": "^2.0"
     },
     "authors": [
         {

--- a/tests/resources/application_config.php
+++ b/tests/resources/application_config.php
@@ -1,13 +1,15 @@
 <?php
 
+$modules = [
+    'Go\ZF2\GoAopModule',
+];
+
+if (class_exists('Zend\Router\Module')) {
+    $modules[] = 'Zend\Router';
+}
+
 return [
-    'modules' => [
-        'Go\ZF2\GoAopModule',
-
-        // Required to initialize application
-        'Zend\Router',
-    ],
-
+    'modules' => $modules,
     'module_listener_options' => [
         'module_paths' => [
             __DIR__ . '/../../vendor',


### PR DESCRIPTION
This runs 3 travis builds with zend version 2 for servicemanager and mvc composer package.

One ugly part is, that it needs zend-view, zend-serializer, zend-log, zend-console and zend-i18n as requirement to initialize the application. We could either add this via travis.yml if we want to keep our composer.json clean. But in this case you can not execute the tests locally for zend version 2.

Any suggestions?

Another thought is to provide an own ServiceListener instance just for testing purposes which does not add all plugin managers.